### PR TITLE
Do not wrap errors returned from SQL

### DIFF
--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -55,13 +55,10 @@ var _closeHook = func(r io.Closer) error {
 
 func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *ResultSets {
 	rows, err := querier.QueryContext(ctx, qry, args...)
-	if err != nil {
-		err = fmt.Errorf("rows.New: %w", err)
-	}
 	return &ResultSets{
 		Rows:    rows,
 		started: false,
-		Err:     err,
+		Err:     err, // important to return the error unadorned here, as some code e.g. casts it directly to mssql.Error
 		Logger:  Logger(ctx),
 	}
 }


### PR DESCRIPTION
This wrapping had little real value and some code downcasts the error returns from SQL driver so less intrusive to directly return original error