### PR TITLE
Fix lost result set on exception

### DIFF
--- a/querysql/logrusmssql.go
+++ b/querysql/logrusmssql.go
@@ -88,14 +88,21 @@ func LogrusMSSQLLogger(logger logrus.FieldLogger, defaultLogLevel logrus.Level) 
 
 func logrusEmitLogEntry(logger logrus.FieldLogger, level logrus.Level) {
 	switch level {
-	case logrus.DebugLevel:
-		logger.Debug()
-	case logrus.InfoLevel:
-		logger.Info()
-	case logrus.WarnLevel:
-		logger.Warning()
+	case logrus.PanicLevel:
+		logger.Panic()
+	case logrus.FatalLevel:
+		logger.Fatal()
 	case logrus.ErrorLevel:
 		logger.Error()
+	case logrus.WarnLevel:
+		logger.Warning()
+	case logrus.InfoLevel:
+		logger.Info()
+	case logrus.DebugLevel:
+	case logrus.TraceLevel:
+		logger.Debug()
+	default:
+		panic(fmt.Sprintf("Log level %d not handled in logrusEmitLogEntry", level))
 	}
 }
 

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -122,14 +122,32 @@ select _=1, log='at end'
 	rs := New(ctx, sqldb, qry, "world")
 	rows := rs.Rows
 
+	// select 2
 	assert.Equal(t, 2, MustNextResult(rs, SingleOf[int]))
+
+	// select X = 1, Y = 'one';
 	assert.Equal(t, row{1, "one"}, MustNextResult(rs, SingleOf[row]))
+
+	// select 'hello' union all select @p1;
 	assert.Equal(t, []string{"hello", "world"}, MustNextResult(rs, SliceOf[string]))
+
+	// select X = 1, Y = 'one' where 1 = 0;
 	assert.Equal(t, []row(nil), MustNextResult(rs, SliceOf[row]))
+
+	// select X = 1, Y = 'one'
+	// union all select X = 2, Y = 'two';
 	assert.Equal(t, []row{{1, "one"}, {2, "two"}}, MustNextResult(rs, SliceOf[row]))
+
+	// select 0x0102030405 union all select 0x0102030406
 	assert.Equal(t, []MyArray{{1, 2, 3, 4, 5}, {1, 2, 3, 4, 6}}, MustNextResult(rs, SliceOf[MyArray]))
+
+	// select concat('hello ', @p1);
 	assert.Equal(t, "hello world", MustNextResult(rs, SingleOf[string]))
+
+	// select 0x0102030405
 	assert.Equal(t, MyArray{1, 2, 3, 4, 5}, MustNextResult(rs, SingleOf[MyArray]))
+
+	// select newid()
 	assert.Equal(t, 16, len(MustNextResult(rs, SingleOf[[]uint8])))
 
 	// Check that we have exhausted the logging select before we do the call that gets ErrNoMoreSets

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -170,6 +170,56 @@ select _=1, log='at end'
 
 }
 
+func Test_LogAndException(t *testing.T) {
+	qry := `
+-- single scalar
+select 2;
+-- single struct
+select X = 1, Y = 'one';
+-- log something
+select _=1, x = 'hello world', y = 1;
+-- single struct
+select X = 2, Y = 'two';
+throw 55002, 'Here is an error', 1;
+select 2;
+`
+
+	type row struct {
+		X int
+		Y string
+	}
+
+	var hook LogHook
+	logger := logrus.StandardLogger()
+	logger.Hooks.Add(&hook)
+	ctx := WithLogger(context.Background(), LogrusMSSQLLogger(logger, logrus.InfoLevel))
+	rs := New(ctx, sqldb, qry, "world")
+
+	// select 2
+	v1, err := NextResult(rs, SingleOf[int])
+	assert.NoError(t, err)
+	assert.Equal(t, 2, v1)
+
+	// select X = 1, Y = 'one'
+	v2, err := NextResult(rs, SingleOf[row])
+	assert.NoError(t, err)
+	assert.Equal(t, row{1, "one"}, v2)
+
+	// select X = 2, Y = 'two'
+	v3, err := NextResult(rs, SingleOf[row])
+	assert.NoError(t, err)
+	assert.Equal(t, row{2, "two"}, v3)
+
+	// throw 55002, 'Here is an error.', 1;
+	_, err = NextResult(rs, SingleOf[row])
+	assert.Equal(t, "mssql: Here is an error", err.Error())
+
+	// Check that we have exhausted the logging select before we do the call that gets ErrNoMoreSets
+	assert.Equal(t, []logrus.Fields{
+		{"x": "hello world", "y": int64(1)},
+	}, hook.lines)
+}
+
 func TestMultipleRowsetsPointers(t *testing.T) {
 	qry := `
 -- single scalar


### PR DESCRIPTION
There is a bug in the library when a valid query that is followed by an exception.  Currently, the library handles the exception and skips the valid query before it.  This PR is to change that behavior.  With this change, we now handle the valid query, and then handle/raise the exception afterwards.

There are a couple of improvements piggy backed with the PR:
- handle different logrun log levels,
- simplification of a `defer close`