### PR TITLE
Implement a dispatcher of Go functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ singleInteger, sliceOfStruct, err := querysql.Query(
 When writing longer multi-statement SQL queries the lack of
 debugging between statements can be a real problem. A work-around
 is provided in this library. Any target-less `select` statements
-where the name of the first column is `_` will be re-directed
+where the name of the first column is `_log` will be re-directed
 to a logger (if one is configured; and otherwise the data will be
 ignored). Example:
 
@@ -102,12 +102,12 @@ qry := `
     select A='one';
 
     -- logging
-    select _=1, hello=@a;
+    select _log='info', hello=@a;
     
     select B='two';
 
     -- log one entry per row, at a non-standard level
-    select _=1, hello=@a from SomeTable;
+    select _log='info', hello=@a from SomeTable;
 
 ` 
 
@@ -123,8 +123,7 @@ to one combination of tools, and you may need to write your
 own implementation of `RowsLogger` based on the one provided in this library.
 The `*sql.Rows` is passed straight through to the `RowsLogger`,
 but by convention the first column in the result will be the special
-column `_`, which may either contain a log-level (`info`, `debug`, `warning`, `error`)
-or some bogus data (such as `1` above) to use a default log level.
+column `_log`, which may either contain a log-level (`info`, `debug`, `warning`, `error`).
 
 ## Advanced use
 

--- a/querysql/context.go
+++ b/querysql/context.go
@@ -7,6 +7,7 @@ import (
 type contextKey int
 
 const ckRowsLogger contextKey = 0
+const ckRowsDispatcher contextKey = 1
 
 // WithLogger will return the context with a logger registered for use with querysql;
 // during queries, querysql will use Logger() to extract the logger from the context
@@ -18,6 +19,18 @@ func Logger(ctx context.Context) RowsLogger {
 	l := ctx.Value(ckRowsLogger)
 	if l != nil {
 		return l.(RowsLogger)
+	}
+	return nil
+}
+
+func WithDispatcher(ctx context.Context, dispatcher RowsGoDispatcher) context.Context {
+	return context.WithValue(ctx, ckRowsDispatcher, dispatcher)
+}
+
+func Dispatcher(ctx context.Context) RowsGoDispatcher {
+	l := ctx.Value(ckRowsDispatcher)
+	if l != nil {
+		return l.(RowsGoDispatcher)
 	}
 	return nil
 }

--- a/querysql/gomssqldispatcher.go
+++ b/querysql/gomssqldispatcher.go
@@ -39,9 +39,9 @@ func GoMSSQLDispatcher(fs []interface{}) RowsGoDispatcher {
 		fInfo.name = getFunctionName(runtime.FuncForPC(fInfo.valueOf.Pointer()).Name())
 
 		if knownFuncs == "" {
-			knownFuncs = fInfo.name
+			knownFuncs = fmt.Sprintf("'%s'", fInfo.name)
 		} else {
-			knownFuncs = fmt.Sprintf("%s, %s", knownFuncs, fInfo.name)
+			knownFuncs = fmt.Sprintf("%s, '%s'", knownFuncs, fInfo.name)
 		}
 
 		typeOfFunc := fInfo.valueOf.Type()
@@ -79,7 +79,7 @@ func GoMSSQLDispatcher(fs []interface{}) RowsGoDispatcher {
 		// with the name of the function to be called
 		fname, ok := fields[0].(string)
 		if !ok {
-			return fmt.Errorf("first argument to 'select' is expected to be a string. Got '%s' of type '%s' instead", fname, reflect.TypeOf(fname).String())
+			return fmt.Errorf("first argument to 'select' is expected to be a string. Got '%v' of type '%s' instead", fields[0], reflect.TypeOf(fields[0]).String())
 		}
 		fInfo, ok := funcMap[fname]
 		if !ok {
@@ -119,7 +119,7 @@ func GoMSSQLDispatcher(fs []interface{}) RowsGoDispatcher {
 			if fArgType != sqlType {
 				// Try to convert the sql value to the expected type
 				if !reflectedValue.CanConvert(fArgType) {
-					return fmt.Errorf("expected parameter '%s' to be of type '%s' but got '%s' instead\n",
+					return fmt.Errorf("expected parameter '%s' to be of type '%s' but got '%s' instead",
 						colTypes[i].Name(),
 						fArgType,
 						sqlType)

--- a/querysql/logrusmssql.go
+++ b/querysql/logrusmssql.go
@@ -41,6 +41,10 @@ func LogrusMSSQLLogger(logger logrus.FieldLogger, defaultLogLevel logrus.Level) 
 			}
 			parsedLogLevel, err := logrus.ParseLevel(logLevel)
 			if err != nil {
+				logrusEmitLogEntry(logger.WithFields(logrus.Fields{
+					"event":         "invalid.log.level",
+					"invalid.level": logLevel,
+				}), logrus.ErrorLevel)
 				parsedLogLevel = defaultLogLevel
 			}
 
@@ -74,7 +78,7 @@ func LogrusMSSQLLogger(logger logrus.FieldLogger, defaultLogLevel logrus.Level) 
 		if !hadRow {
 			// it can be quite annoying to have logging of empty tables turn into nothing, so log
 			// an indication that the log statement was there, with an empty table
-			// in this case loglevel is unreachable and we really can only log the keys,
+			// in this case loglevel is unreachable, and we really can only log the keys,
 			// but let's hope INFO isn't overboard
 			l := logger.WithField("_norows", true)
 			for _, col := range cols[1:] {

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vippsas/go-querysql/querysql/testhelper"
 )
 
 type MyArray [5]byte
@@ -76,19 +77,19 @@ select 2;
 select X = 1, Y = 'one';
 
 -- log something
-select _=1, x = 'hello world', y = 1;
+select _log='info', x = 'hello world', y = 1;
 
 -- multiple scalar
 select 'hello' union all select @p1;
 
 -- log something
-select _=1, x = 'hello world2', y = 2;
+select _log='info', x = 'hello world2', y = 2;
 -- log something again without a result in between
-select _=1, x = 'hello world3', y = 3
-union all select _=2, x='hello world3', y= 4
+select _log='info', x = 'hello world3', y = 3
+union all select _log='info', x='hello world3', y= 4
 
 -- logging of 0 rows
-select _=1, x=1 from (select 1 as y where 1 = 0) tmp
+select _log='info', x=1 from (select 1 as y where 1 = 0) tmp
 
 -- empty struct slice
 select X = 1, Y = 'one' where 1 = 0;
@@ -106,8 +107,10 @@ select 0x0102030405
 select newid()
 
 -- logging in the end
-select _=1, log='at end'
+select _log='info', log='at end'
 
+-- dispatcher
+select _function='TestFunction', component = 'abc', val=1, time=1.23;
 `
 
 	type row struct {
@@ -119,6 +122,9 @@ select _=1, log='at end'
 	logger := logrus.StandardLogger()
 	logger.Hooks.Add(&hook)
 	ctx := WithLogger(context.Background(), LogrusMSSQLLogger(logger, logrus.InfoLevel))
+	ctx = WithDispatcher(ctx, GoMSSQLDispatcher([]interface{}{
+		testhelper.TestFunction,
+	}))
 	rs := New(ctx, sqldb, qry, "world")
 	rows := rs.Rows
 
@@ -160,6 +166,9 @@ select _=1, log='at end'
 		{"log": "at end"},
 	}, hook.lines)
 
+	NextResult(rs, SliceOf[string])
+	assert.True(t, testhelper.TestFunctionCalled)
+
 	_, err := NextResult(rs, SingleOf[int])
 	assert.Equal(t, ErrNoMoreSets, err)
 	assert.True(t, isClosed(rows))
@@ -170,6 +179,28 @@ select _=1, log='at end'
 
 }
 
+func TestInvalidLogLevel(t *testing.T) {
+	qry := `
+-- log something
+select _log=1, x = 'hello world', y = 1;
+`
+
+	var hook LogHook
+	logger := logrus.StandardLogger()
+	logger.Hooks.Add(&hook)
+	ctx := WithLogger(context.Background(), LogrusMSSQLLogger(logger, logrus.InfoLevel))
+	rs := New(ctx, sqldb, qry, "world")
+	err := NextNoScanner(rs)
+	assert.Error(t, err)
+	assert.Equal(t, "no more result sets", err.Error())
+
+	// Check that we have exhausted the logging select before we do the call that gets ErrNoMoreSets
+	assert.Equal(t, []logrus.Fields{
+		{"event": "invalid.log.level", "invalid.level": "1"},
+		{"x": "hello world", "y": int64(1)},
+	}, hook.lines)
+}
+
 func Test_LogAndException(t *testing.T) {
 	qry := `
 -- single scalar
@@ -177,7 +208,7 @@ select 2;
 -- single struct
 select X = 1, Y = 'one';
 -- log something
-select _=1, x = 'hello world', y = 1;
+select _log='info', x = 'hello world', y = 1;
 -- single struct
 select X = 2, Y = 'two';
 throw 55002, 'Here is an error', 1;
@@ -239,8 +270,8 @@ select X = 1, Y = 'one'
 union all select X = 2, Y = 'two';
 
 -- piggy-back a test for logging selects when no logger is configured on the ctx
-select _=1, this='will never be seen'
-union all select _=1, this='also silenced';
+select _log='info', this='will never be seen'
+union all select _log='info', this='also silenced';
 
 -- multiple sql.Scanner
 select 0x0102030405 union all select 0x0102030406
@@ -367,7 +398,7 @@ func TestNoResultSets(t *testing.T) {
 
 func TestOnlyLoggingResultSets(t *testing.T) {
 	// when there are only logging result sets, make sure error is ErrNoMoreSets
-	qry := `select _=1, x=1;`
+	qry := `select _log='info', x=1;`
 	_, err := Slice[int](context.Background(), sqldb, qry)
 	require.NotNil(t, err)
 	require.Equal(t, ErrNoMoreSets, err)

--- a/querysql/testhelper/helper.go
+++ b/querysql/testhelper/helper.go
@@ -1,7 +1,44 @@
 package testhelper
 
-var TestFunctionCalled bool
+import (
+	"runtime"
+	"strings"
+)
+
+var TestFunctionsCalled = map[string]bool{
+	"TestFunction":      false,
+	"OtherTestFunction": false,
+}
 
 func TestFunction(component string, val int64, t float64) {
-	TestFunctionCalled = true
+	TestFunctionsCalled[getFunctionName()] = true
+}
+
+func OtherTestFunction() {
+	TestFunctionsCalled[getFunctionName()] = true
+}
+
+func ResetTestFunctionsCalled() {
+	for k, _ := range TestFunctionsCalled {
+		TestFunctionsCalled[k] = false
+	}
+}
+
+func getFunctionName() string {
+	pc, _, _, ok := runtime.Caller(1) // 1 means we get the caller of the function
+	if !ok {
+		panic("Could not get function name")
+	}
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		panic("Could not get function name")
+	}
+
+	cleanUpName := func(fullName string) string {
+		paths := strings.Split(fullName, "/")
+		lastPath := paths[len(paths)-1]
+		parts := strings.Split(lastPath, ".")
+		return parts[len(parts)-1]
+	}
+	return cleanUpName(fn.Name())
 }

--- a/querysql/testhelper/helper.go
+++ b/querysql/testhelper/helper.go
@@ -1,0 +1,7 @@
+package testhelper
+
+var TestFunctionCalled bool
+
+func TestFunction(component string, val int64, t float64) {
+	TestFunctionCalled = true
+}


### PR DESCRIPTION
Be able to call a Go function from SQL with:

select _function='FuncName', arg=val
with a similar mechanism to the one we use for logging (select _=1, event='bla').

The functions must have been passed to go-querysql previously.

This allows, for example, us to send metrics to prometheus with values from we get from inside SQL (like inside a stored procedure).