### PR TITLE
Dispatcher to handle anon func returned in closure

### DIFF
--- a/querysql/testhelper/helper.go
+++ b/querysql/testhelper/helper.go
@@ -23,6 +23,12 @@ func OtherTestFunction(time float64, money float64) {
 	TestFunctionsCalled[getFunctionName()] = true
 }
 
+func ReturnAnonFunc(component string) func(string, float64) {
+	return func(label string, time float64) {
+		TestFunctionsCalled[fmt.Sprintf("ReturnAnonFunc.%s", component)] = true
+	}
+}
+
 func ResetTestFunctionsCalled() {
 	for k, _ := range TestFunctionsCalled {
 		TestFunctionsCalled[k] = false


### PR DESCRIPTION
Take this higher order function that returns an anonymous function:

```
func ReturnAnonFunc(component string) func(string, float64) {
	return func(label string, time float64) {
		TestFunctionsCalled[fmt.Sprintf("ReturnAnonFunc.%s", component)] = true
	}
}
```

We can now register with dispatcher like so:

```
	ctx = querysql.WithDispatcher(ctx, querysql.GoMSSQLDispatcher([]interface{}{
		testhelper.ReturnAnonFunc("myComponent"),
	}))
```

That's because the anon function is named in go as `ReturnAnonFunc.func1`.  So, we can use the `ReturnAnonFunc` part of the anonymous function name in order to dispatch the correct function at runtime.

This means we can have one anonymous function per high-order function.  Meaning, the dispatcher cannot disambiguate between:

```
testhelper.ReturnAnonFunc("myComponent"),
testhelper.ReturnAnonFunc("myComponent2"),
```

Therefore, if the user tries to record more than one anon functions from the same higher-order function, the dispatcher will panic.