### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: go-querysql-test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/vippsas/go-querysql/security/code-scanning/1](https://github.com/vippsas/go-querysql/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any actions requiring write access, we can set the permissions to `contents: read`. This ensures that the `GITHUB_TOKEN` has only the minimal privileges necessary for the workflow to function.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs. This avoids redundancy and ensures consistency across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
