### PR TITLE
Add reflection feature for marking a field as optional. Documented th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,51 @@ automatically closed; although it is still a good idea to `defer rs.Close()` in
 case you do not reach the point where `rs.Done() == true`.
 
 
+## Struct tags
+
+The `refl` struct tag controls how querysql maps SQL columns to struct fields.
+
+### `refl:"recurse"` — recurse into named struct fields
+
+By default, querysql only recurses into **anonymous (embedded)** struct fields.
+Use `refl:"recurse"` on a named struct field to also flatten its sub-fields:
+
+```go
+type Address struct {
+    Street string
+    City   string
+}
+
+type Person struct {
+    Name    string
+    Address Address `refl:"recurse"` // Street and City are mapped as top-level columns
+}
+```
+
+### `refl:"optional"` — tolerate absent SQL columns
+
+Mark a field as optional to silently use its zero value when the SQL query does
+not return a matching column. Without this tag, a missing column produces an
+error (`"failed to map all struct fields to query columns"`).
+
+```go
+type Row struct {
+    ID    int
+    Score *float64 `refl:"optional"` // stays nil if the query doesn't return "Score"
+}
+```
+
+### Combining tags
+
+Both options can be combined on the same field:
+
+```go
+type Row struct {
+    Name  string
+    Extra ExtraFields `refl:"recurse,optional"` // recurse AND treat all sub-fields as optional
+}
+```
+
 ## Future plans
 
 * Allow querying directly into `map` types, using the first columns

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -583,6 +583,73 @@ func TestStructScanError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestOptionalField_AbsentFromQuery(t *testing.T) {
+	// An optional field that has no matching SQL column keeps its zero value.
+	type rowWithOptional struct {
+		X int
+		Y int    `refl:"optional"`
+	}
+
+	rows, err := querysql.Slice[rowWithOptional](context.Background(), sqldb, `select 1 as X`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, rowWithOptional{X: 1, Y: 0}, rows[0])
+}
+
+func TestOptionalField_PresentInQuery(t *testing.T) {
+	// An optional field that IS present in the SQL result is populated normally.
+	type rowWithOptional struct {
+		X int
+		Y int `refl:"optional"`
+	}
+
+	rows, err := querysql.Slice[rowWithOptional](context.Background(), sqldb, `select 1 as X, 2 as Y`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, rowWithOptional{X: 1, Y: 2}, rows[0])
+}
+
+func TestOptionalField_PointerTypeStaysNil(t *testing.T) {
+	// An optional pointer field has no matching column and stays nil.
+	type rowWithOptionalPtr struct {
+		X int
+		Y *int `refl:"optional"`
+	}
+
+	rows, err := querysql.Slice[rowWithOptionalPtr](context.Background(), sqldb, `select 42 as X`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, 42, rows[0].X)
+	assert.Nil(t, rows[0].Y)
+}
+
+func TestOptionalField_NonOptionalMissingStillErrors(t *testing.T) {
+	// A non-optional field that has no matching SQL column still produces an error.
+	type rowRequired struct {
+		X int
+		Y int
+	}
+
+	_, err := querysql.Slice[rowRequired](context.Background(), sqldb, `select 1 as X`)
+	assert.Error(t, err)
+}
+
+func TestOptionalField_RecurseAndOptionalCombined(t *testing.T) {
+	// refl:"recurse,optional" on a named struct field: its sub-fields are optional.
+	type extra struct {
+		Z int
+	}
+	type row struct {
+		X     int
+		Extra extra `refl:"recurse,optional"`
+	}
+
+	rows, err := querysql.Slice[row](context.Background(), sqldb, `select 1 as X`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, row{X: 1, Extra: extra{Z: 0}}, rows[0])
+}
+
 func TestExecContext(t *testing.T) {
 	qry := `
 if OBJECT_ID('dbo.MyUsers', 'U') is not null drop table MyUsers

--- a/querysql/reflection.go
+++ b/querysql/reflection.go
@@ -43,12 +43,10 @@ func getPointersToFields(rows *sql.Rows, pointerToStruct interface{}) ([]interfa
 	// Reorder pointers to match query column order
 	ptrs := make([]interface{}, 0, len(columns))
 	mappedNames := make([]string, 0, len(columns))
-	n := 0
 	for _, col := range columns {
 		if j, ok := name2index[col]; ok {
 			ptrs = append(ptrs, origPtrs[j])
 			mappedNames = append(mappedNames, names[j])
-			n++
 		}
 	}
 

--- a/querysql/reflection.go
+++ b/querysql/reflection.go
@@ -23,6 +23,13 @@ func getPointersToFields(rows *sql.Rows, pointerToStruct interface{}) ([]interfa
 		names[i] = canonicalName(name)
 	}
 
+	// Get the names of fields marked refl:"optional"; these are allowed to
+	// be absent from the query result and will keep their zero value.
+	optionalSet := make(map[string]bool)
+	for _, name := range deepOptionalFieldNamesOfStructType(reflect.TypeOf(pointerToStruct)) {
+		optionalSet[canonicalName(name)] = true
+	}
+
 	// Build a mapping from name to index, this index is
 	// both for names[i] and origPtrs[i]
 	name2index := make(map[string]int, len(names))
@@ -45,16 +52,25 @@ func getPointersToFields(rows *sql.Rows, pointerToStruct interface{}) ([]interfa
 		}
 	}
 
-	// Demand that all fields in struct gets filled
-	if n != len(names) {
-		diff := stringSliceDiff(names, columns)
-		return nil, fmt.Errorf("failed to map all struct fields to query columns (names: %v, columns: %v, diff: %v)", names, columns, diff)
+	// Demand that all non-optional fields in the struct get filled.
+	// Optional fields that have no matching column simply keep their zero value.
+	requiredCount := 0
+	requiredNames := []string{}
+	for _, name := range names {
+		if !optionalSet[name] {
+			requiredCount++
+			requiredNames = append(requiredNames, name)
+		}
+	}
+	if n < requiredCount {
+		diff := stringSliceDiff(requiredNames, columns)
+		return nil, fmt.Errorf("failed to map all struct fields to query columns (names: %v, columns: %v, diff: %v)", requiredNames, columns, diff)
 	}
 
 	// Demand that all query columns gets scanned
 	if len(columns) > len(ptrs) {
-		diff := stringSliceDiff(names, columns)
-		return nil, fmt.Errorf("failed to map all query columns to struct fields (names: %v, columns: %v, diff: %v)", names, columns, diff)
+		diff := stringSliceDiff(requiredNames, columns)
+		return nil, fmt.Errorf("failed to map all query columns to struct fields (names: %v, columns: %v, diff: %v)", requiredNames, columns, diff)
 	}
 	return ptrs, nil
 }
@@ -107,6 +123,17 @@ func MustStructType(v reflect.Type) reflect.Type {
 	return v
 }
 
+// hasReflTag reports whether the struct tag's "refl" value contains option.
+// The value may be a comma-separated list, e.g. `refl:"recurse,optional"`.
+func hasReflTag(tag reflect.StructTag, option string) bool {
+	for _, part := range strings.Split(tag.Get("refl"), ",") {
+		if part == option {
+			return true
+		}
+	}
+	return false
+}
+
 func deepFieldsOfStructValue(val reflect.Value) []reflect.Value {
 	v := MustStructValue(val)
 	n := v.NumField()
@@ -115,7 +142,7 @@ func deepFieldsOfStructValue(val reflect.Value) []reflect.Value {
 		f := v.Field(i)
 		tf := v.Type().Field(i)
 		k := tf.Type.Kind()
-		if k == reflect.Struct && (tf.Anonymous || tf.Tag.Get("refl") == "recurse") {
+		if k == reflect.Struct && (tf.Anonymous || hasReflTag(tf.Tag, "recurse")) {
 			fields = append(fields, deepFieldsOfStructValue(f)...)
 		} else {
 			fields = append(fields, f)
@@ -136,10 +163,36 @@ func deepFieldNamesOfStructType(typ reflect.Type) []string {
 	for i := 0; i < n; i++ {
 		f := t.Field(i)
 		k := f.Type.Kind()
-		if k == reflect.Struct && (f.Anonymous || f.Tag.Get("refl") == "recurse") {
+		if k == reflect.Struct && (f.Anonymous || hasReflTag(f.Tag, "recurse")) {
 			names = append(names, deepFieldNamesOfStructType(f.Type)...)
 		} else {
 			names = append(names, t.Field(i).Name)
+		}
+	}
+	return names
+}
+
+// deepOptionalFieldNamesOfStructType returns the names of fields marked with
+// the refl:"optional" tag.
+//
+// When a struct field carries refl:"recurse,optional", all child fields recursed
+// from it are also treated as optional.
+func deepOptionalFieldNamesOfStructType(typ reflect.Type) []string {
+	return deepOptionalFieldNamesHelper(typ, false)
+}
+
+func deepOptionalFieldNamesHelper(typ reflect.Type, parentOptional bool) []string {
+	t := MustStructType(typ)
+	n := t.NumField()
+	names := make([]string, 0)
+	for i := 0; i < n; i++ {
+		f := t.Field(i)
+		k := f.Type.Kind()
+		isOptional := parentOptional || hasReflTag(f.Tag, "optional")
+		if k == reflect.Struct && (f.Anonymous || hasReflTag(f.Tag, "recurse")) {
+			names = append(names, deepOptionalFieldNamesHelper(f.Type, isOptional)...)
+		} else if isOptional {
+			names = append(names, f.Name)
 		}
 	}
 	return names

--- a/querysql/reflection.go
+++ b/querysql/reflection.go
@@ -54,23 +54,27 @@ func getPointersToFields(rows *sql.Rows, pointerToStruct interface{}) ([]interfa
 
 	// Demand that all non-optional fields in the struct get filled.
 	// Optional fields that have no matching column simply keep their zero value.
-	requiredCount := 0
 	requiredNames := []string{}
 	for _, name := range names {
 		if !optionalSet[name] {
-			requiredCount++
 			requiredNames = append(requiredNames, name)
 		}
 	}
-	if n < requiredCount {
+	requiredMapped := 0
+	for _, mappedName := range mappedNames {
+		if !optionalSet[mappedName] {
+			requiredMapped++
+		}
+	}
+	if requiredMapped < len(requiredNames) {
 		diff := stringSliceDiff(requiredNames, columns)
 		return nil, fmt.Errorf("failed to map all struct fields to query columns (names: %v, columns: %v, diff: %v)", requiredNames, columns, diff)
 	}
 
 	// Demand that all query columns gets scanned
 	if len(columns) > len(ptrs) {
-		diff := stringSliceDiff(requiredNames, columns)
-		return nil, fmt.Errorf("failed to map all query columns to struct fields (names: %v, columns: %v, diff: %v)", requiredNames, columns, diff)
+		diff := stringSliceDiff(names, columns)
+		return nil, fmt.Errorf("failed to map all query columns to struct fields (names: %v, columns: %v, diff: %v)", names, columns, diff)
 	}
 	return ptrs, nil
 }

--- a/querysql/reflection_error_test.go
+++ b/querysql/reflection_error_test.go
@@ -1,0 +1,130 @@
+package querysql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vippsas/go-querysql/querysql"
+)
+
+type mappingErrorExpectation struct {
+	errorPrefix string
+	names       []string
+	columns     []string
+	diff        map[string]int
+}
+
+// assertMappingError checks that err matches the expected getPointersToFields error format:
+//
+//	"<errorPrefix> (names: <names>, columns: <columns>, diff: <diff>)"
+func assertMappingError(t *testing.T, err error, expected mappingErrorExpectation) {
+	t.Helper()
+	require.Error(t, err)
+
+	expectedMsg := fmt.Sprintf("%s (names: %v, columns: %v, diff: %v)",
+		expected.errorPrefix, expected.names, expected.columns, expected.diff)
+	assert.Equal(t, expectedMsg, err.Error())
+}
+
+func TestGetPointersToFields_StructFieldMissingFromQuery(t *testing.T) {
+	type row struct {
+		X int
+		Y string
+	}
+	rs := querysql.New(context.Background(), sqldb, `select X = 1`)
+	defer rs.Close()
+
+	_, err := querysql.NextResult(rs, querysql.SingleOf[row])
+	assertMappingError(t, err, mappingErrorExpectation{
+		errorPrefix: "failed to map all struct fields to query columns",
+		names:       []string{"x", "y"},
+		columns:     []string{"x"},
+		diff:        map[string]int{"y": 1},
+	})
+}
+
+func TestGetPointersToFields_QueryColumnMissingFromStruct(t *testing.T) {
+	type row struct {
+		X int
+		Y string
+	}
+	rs := querysql.New(context.Background(), sqldb, `select X = 1, Y = 'one', Z = 2`)
+	defer rs.Close()
+
+	_, err := querysql.NextResult(rs, querysql.SingleOf[row])
+	assertMappingError(t, err, mappingErrorExpectation{
+		errorPrefix: "failed to map all query columns to struct fields",
+		names:       []string{"x", "y"},
+		columns:     []string{"x", "y", "z"},
+		diff:        map[string]int{"z": -1},
+	})
+}
+
+func TestGetPointersToFields_OptionalFieldMissingIsNotAnError(t *testing.T) {
+	type row struct {
+		X int
+		Y string `refl:"optional"`
+	}
+	rs := querysql.New(context.Background(), sqldb, `select X = 1`)
+	defer rs.Close()
+
+	val, err := querysql.NextResult(rs, querysql.SingleOf[row])
+	assert.NoError(t, err)
+	assert.Equal(t, 1, val.X)
+	assert.Equal(t, "", val.Y) // zero value since it's optional and missing
+}
+
+func TestGetPointersToFields_RequiredFieldMissingWithOptionalPresent(t *testing.T) {
+	type row struct {
+		X int
+		Y string
+		Z int `refl:"optional"`
+	}
+	rs := querysql.New(context.Background(), sqldb, `select X = 1`)
+	defer rs.Close()
+
+	_, err := querysql.NextResult(rs, querysql.SingleOf[row])
+	assertMappingError(t, err, mappingErrorExpectation{
+		errorPrefix: "failed to map all struct fields to query columns",
+		names:       []string{"x", "y"},
+		columns:     []string{"x"},
+		diff:        map[string]int{"y": 1},
+	})
+}
+
+func TestGetPointersToFields_MultipleFieldsMissingFromQuery(t *testing.T) {
+	type row struct {
+		X int
+		Y string
+		Z int
+	}
+	rs := querysql.New(context.Background(), sqldb, `select X = 1`)
+	defer rs.Close()
+
+	_, err := querysql.NextResult(rs, querysql.SingleOf[row])
+	assertMappingError(t, err, mappingErrorExpectation{
+		errorPrefix: "failed to map all struct fields to query columns",
+		names:       []string{"x", "y", "z"},
+		columns:     []string{"x"},
+		diff:        map[string]int{"y": 1, "z": 1},
+	})
+}
+
+func TestGetPointersToFields_MultipleExtraQueryColumns(t *testing.T) {
+	type row struct {
+		X int
+	}
+	rs := querysql.New(context.Background(), sqldb, `select X = 1, Y = 'one', Z = 2, W = 3`)
+	defer rs.Close()
+
+	_, err := querysql.NextResult(rs, querysql.SingleOf[row])
+	assertMappingError(t, err, mappingErrorExpectation{
+		errorPrefix: "failed to map all query columns to struct fields",
+		names:       []string{"x"},
+		columns:     []string{"x", "y", "z", "w"},
+		diff:        map[string]int{"y": -1, "z": -1, "w": -1},
+	})
+}

--- a/querysql/reflection_error_test.go
+++ b/querysql/reflection_error_test.go
@@ -95,6 +95,28 @@ func TestGetPointersToFields_RequiredFieldMissingWithOptionalPresent(t *testing.
 	})
 }
 
+// TestGetPointersToFields_RequiredFieldMissingWhenOptionalFieldPresentInQuery is a regression
+// test for a bug where `n` (total mapped columns) was compared against `requiredCount` instead
+// of counting only required mapped columns. When an optional column was present in the query,
+// `n` could equal `requiredCount` even though a required field had no matching column.
+func TestGetPointersToFields_RequiredFieldMissingWhenOptionalFieldPresentInQuery(t *testing.T) {
+	type row struct {
+		X int
+		Y string    // required — will be absent from query
+		Z int `refl:"optional"` // optional — will be present in query
+	}
+	// Query returns X and Z (optional), but omits Y (required).
+	// Old code: n=2, requiredCount=2 → 2 < 2 → no error (bug).
+	// Fixed code: requiredMapped=1 (only X), len(requiredNames)=2 → error.
+	rs := querysql.New(context.Background(), sqldb, `select X = 1, Z = 99`)
+	defer rs.Close()
+
+	_, err := querysql.NextResult(rs, querysql.SingleOf[row])
+	require.Error(t, err, "expected error because required field Y is missing from query")
+	assert.Contains(t, err.Error(), "failed to map all struct fields to query columns")
+	assert.Contains(t, err.Error(), "y")
+}
+
 func TestGetPointersToFields_MultipleFieldsMissingFromQuery(t *testing.T) {
 	type row struct {
 		X int


### PR DESCRIPTION
This allows us to mark a field as optional, which is useful for some cases such as:
1. When a struct can be optionally used with querysql, such as in our Table and Form library. 