### PR TITLE
fix(dispatcher): defer Go dispatch until query completion

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,5 +25,16 @@ jobs:
     - name: Start db
       run: docker compose -f docker-compose.test.yml up -d
 
+    - name: Wait for db
+      run: |
+        for i in {1..60}; do
+          if docker logs mssql 2>&1 | grep -q "SQL Server is now ready for client connections"; then
+            exit 0
+          fi
+          sleep 2
+        done
+        docker logs mssql
+        exit 1
+
     - name: Test
       run: go test -v ./...

--- a/querysql/context.go
+++ b/querysql/context.go
@@ -23,28 +23,15 @@ func Logger(ctx context.Context) RowsLogger {
 	return nil
 }
 
-// WithDispatcher registers either a RowsGoDispatcher or a DeferredRowsGoDispatcher on the context.
-func WithDispatcher(ctx context.Context, dispatcher any) context.Context {
+// WithDispatcher registers a dispatcher for _function result sets.
+func WithDispatcher(ctx context.Context, dispatcher RowsGoDispatcher) context.Context {
 	return context.WithValue(ctx, ckRowsDispatcher, dispatcher)
 }
 
-func dispatcherValue(ctx context.Context) any {
-	l := ctx.Value(ckRowsDispatcher)
-	return l
-}
-
-// Dispatcher returns the legacy immediate dispatcher, if one was registered.
-// Deferred dispatchers are available internally through the context value used by ResultSets.
 func Dispatcher(ctx context.Context) RowsGoDispatcher {
 	l := ctx.Value(ckRowsDispatcher)
 	if l == nil {
 		return nil
 	}
-
-	dispatcher, ok := l.(RowsGoDispatcher)
-	if !ok {
-		return nil
-	}
-
-	return dispatcher
+	return l.(RowsGoDispatcher)
 }

--- a/querysql/context.go
+++ b/querysql/context.go
@@ -23,14 +23,28 @@ func Logger(ctx context.Context) RowsLogger {
 	return nil
 }
 
-func WithDispatcher(ctx context.Context, dispatcher RowsGoDispatcher) context.Context {
+// WithDispatcher registers either a RowsGoDispatcher or a DeferredRowsGoDispatcher on the context.
+func WithDispatcher(ctx context.Context, dispatcher any) context.Context {
 	return context.WithValue(ctx, ckRowsDispatcher, dispatcher)
 }
 
+func dispatcherValue(ctx context.Context) any {
+	l := ctx.Value(ckRowsDispatcher)
+	return l
+}
+
+// Dispatcher returns the legacy immediate dispatcher, if one was registered.
+// Deferred dispatchers are available internally through the context value used by ResultSets.
 func Dispatcher(ctx context.Context) RowsGoDispatcher {
 	l := ctx.Value(ckRowsDispatcher)
-	if l != nil {
-		return l.(RowsGoDispatcher)
+	if l == nil {
+		return nil
 	}
-	return nil
+
+	dispatcher, ok := l.(RowsGoDispatcher)
+	if !ok {
+		return nil
+	}
+
+	return dispatcher
 }

--- a/querysql/gomssqldispatcher.go
+++ b/querysql/gomssqldispatcher.go
@@ -18,9 +18,18 @@ type funcInfo struct {
 	valueOf   reflect.Value
 }
 
-func GoMSSQLDispatcher(fs []interface{}) RowsGoDispatcher {
-	var knownFuncs string
-	var funcMap = map[string]funcInfo{}
+type deferredFuncCall func() error
+
+type goMSSQLDispatcher struct {
+	knownFuncs string
+	funcMap    map[string]funcInfo
+	pending    []deferredFuncCall
+}
+
+func GoMSSQLDispatcher(fs []interface{}) DeferredRowsGoDispatcher {
+	dispatcher := &goMSSQLDispatcher{
+		funcMap: map[string]funcInfo{},
+	}
 
 	// Check if the `fs` passed in are indeed functions and construct a map of func name to func
 	for _, f := range fs {
@@ -48,10 +57,10 @@ func GoMSSQLDispatcher(fs []interface{}) RowsGoDispatcher {
 		}
 		fInfo.name, fInfo.isClosure = getFunctionName(runtime.FuncForPC(fInfo.valueOf.Pointer()).Name())
 
-		if knownFuncs == "" {
-			knownFuncs = fmt.Sprintf("'%s'", fInfo.name)
+		if dispatcher.knownFuncs == "" {
+			dispatcher.knownFuncs = fmt.Sprintf("'%s'", fInfo.name)
 		} else {
-			knownFuncs = fmt.Sprintf("%s, '%s'", knownFuncs, fInfo.name)
+			dispatcher.knownFuncs = fmt.Sprintf("%s, '%s'", dispatcher.knownFuncs, fInfo.name)
 		}
 
 		typeOfFunc := fInfo.valueOf.Type()
@@ -61,106 +70,129 @@ func GoMSSQLDispatcher(fs []interface{}) RowsGoDispatcher {
 		for i := 0; i < fInfo.numArgs; i++ {
 			fInfo.argType[i] = funcType.In(i)
 		}
-		if _, in := funcMap[fInfo.name]; in {
+		if _, in := dispatcher.funcMap[fInfo.name]; in {
 			panic(fmt.Sprintf("Function already in dispatcher %s (closure==%v)", fInfo.name, fInfo.isClosure))
 		}
-		funcMap[fInfo.name] = fInfo
+		dispatcher.funcMap[fInfo.name] = fInfo
 	}
 
-	return func(rows *sql.Rows) error {
-		cols, err := rows.Columns()
-		if err != nil {
+	return dispatcher
+}
+
+func (d *goMSSQLDispatcher) ProcessRows(rows *sql.Rows) error {
+	cols, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return err
+	}
+
+	fields := make([]interface{}, len(cols))
+	scanPointers := make([]interface{}, len(cols))
+	for i := 0; i < len(cols); i++ {
+		scanPointers[i] = &fields[i]
+	}
+	for rows.Next() {
+		if err = rows.Scan(scanPointers...); err != nil {
 			return err
 		}
-		colTypes, err := rows.ColumnTypes()
-		if err != nil {
-			return err
+	}
+
+	// The first argument to the select is expected to be a string
+	// with the name of the function to be called
+	fname, ok := fields[0].(string)
+	if !ok {
+		// The first argument is expected to be a string, but we can get nil if we do something like `select _function=... where 1=2`
+		// The lack of results is not an error, and it just means there is nothing to do
+		if fields[0] == nil {
+			return nil
+		}
+		return fmt.Errorf("first argument to 'select' is expected to be a string. Got '%v' of type '%s' instead", fields[0], reflect.TypeOf(fields[0]).String())
+	}
+	fInfo, ok := d.funcMap[fname]
+	if !ok {
+		return fmt.Errorf("could not find '%s'.  The first argument to 'select' must be the name of a function passed into the dispatcher.  Expected one of %s", fname, d.knownFuncs)
+	}
+
+	if len(cols)-1 != fInfo.numArgs {
+		return fmt.Errorf("incorrect number of parameters for function '%s'", fname)
+	}
+
+	// Set up the args for calling the function later when the query outcome is known.
+	in := make([]reflect.Value, fInfo.numArgs)
+	for i, value := range fields {
+		if i == 0 {
+			continue // function name
 		}
 
-		fields := make([]interface{}, len(cols))
-		scanPointers := make([]interface{}, len(cols))
-		for i := 0; i < len(cols); i++ {
-			scanPointers[i] = &fields[i]
-		}
-		for rows.Next() {
-			if err = rows.Scan(scanPointers...); err != nil {
-				return err
-			}
-		}
-
-		// The first argument to the select is expected to be a string
-		// with the name of the function to be called
-		fname, ok := fields[0].(string)
-		if !ok {
-			// The first argument is expected to be a string, but we can get nil if we do something like `select _function=... where 1=2`
-			// The lack of results is not an error, and it just means there is nothing to do
-			if fields[0] == nil {
-				return nil
-			}
-			return fmt.Errorf("first argument to 'select' is expected to be a string. Got '%v' of type '%s' instead", fields[0], reflect.TypeOf(fields[0]).String())
-		}
-		fInfo, ok := funcMap[fname]
-		if !ok {
-			return fmt.Errorf("could not find '%s'.  The first argument to 'select' must be the name of a function passed into the dispatcher.  Expected one of %s", fname, knownFuncs)
-		}
-
-		if len(cols)-1 != fInfo.numArgs {
-			return fmt.Errorf("incorrect number of parameters for function '%s'", fname)
-		}
-
-		// Set up the args for calling fo the function
-		in := make([]reflect.Value, fInfo.numArgs)
-		for i, value := range fields {
-			if i == 0 {
-				continue // function name
-			}
-
-			// Convert MSSQL types to Go types
-			switch typedValue := value.(type) {
-			case []uint8:
-				switch colTypes[i].DatabaseTypeName() {
-				case "DECIMAL":
-					str := string(typedValue)
-					value, err = strconv.ParseFloat(str, 64)
-					if err != nil {
-						return fmt.Errorf("could not convert argument '%s' of '%s' to float64",
-							str,
-							colTypes[i].Name())
-					}
-				case "MONEY":
-					str := string(typedValue)
-					value, err = strconv.ParseFloat(str, 64)
-					if err != nil {
-						return fmt.Errorf("could not convert argument '%s' of '%s' to float64",
-							str,
-							colTypes[i].Name())
-					}
+		// Convert MSSQL types to Go types
+		switch typedValue := value.(type) {
+		case []uint8:
+			switch colTypes[i].DatabaseTypeName() {
+			case "DECIMAL":
+				str := string(typedValue)
+				value, err = strconv.ParseFloat(str, 64)
+				if err != nil {
+					return fmt.Errorf("could not convert argument '%s' of '%s' to float64",
+						str,
+						colTypes[i].Name())
+				}
+			case "MONEY":
+				str := string(typedValue)
+				value, err = strconv.ParseFloat(str, 64)
+				if err != nil {
+					return fmt.Errorf("could not convert argument '%s' of '%s' to float64",
+						str,
+						colTypes[i].Name())
 				}
 			}
-
-			// Check if SQL type and Go func type match
-			reflectedValue := reflect.ValueOf(value)
-			sqlType := reflect.TypeOf(value)
-			fArgType := fInfo.argType[i-1]
-			if fArgType != sqlType {
-				// Try to convert the sql value to the expected type
-				if !reflectedValue.CanConvert(fArgType) {
-					return fmt.Errorf("expected parameter '%s' to be of type '%s' but got '%s' instead",
-						colTypes[i].Name(),
-						fArgType,
-						sqlType)
-				}
-				reflectedValue = reflectedValue.Convert(fArgType)
-			}
-			in[i-1] = reflectedValue
 		}
 
+		// Check if SQL type and Go func type match
+		reflectedValue := reflect.ValueOf(value)
+		sqlType := reflect.TypeOf(value)
+		fArgType := fInfo.argType[i-1]
+		if fArgType != sqlType {
+			// Try to convert the sql value to the expected type
+			if !reflectedValue.CanConvert(fArgType) {
+				return fmt.Errorf("expected parameter '%s' to be of type '%s' but got '%s' instead",
+					colTypes[i].Name(),
+					fArgType,
+					sqlType)
+			}
+			reflectedValue = reflectedValue.Convert(fArgType)
+		}
+		in[i-1] = reflectedValue
+	}
+
+	d.pending = append(d.pending, func() error {
 		fInfo.valueOf.Call(in)
+		return nil
+	})
 
-		if err = rows.Err(); err != nil {
-			return err
-		}
+	if err = rows.Err(); err != nil {
+		return err
+	}
 
+	return nil
+}
+
+func (d *goMSSQLDispatcher) Finalize(queryErr error) error {
+	defer func() {
+		d.pending = nil
+	}()
+
+	if queryErr != nil {
 		return nil
 	}
+
+	for _, fn := range d.pending {
+		if err := fn(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/querysql/gomssqldispatcher.go
+++ b/querysql/gomssqldispatcher.go
@@ -26,7 +26,7 @@ type goMSSQLDispatcher struct {
 	pending    []deferredFuncCall
 }
 
-func GoMSSQLDispatcher(fs []interface{}) DeferredRowsGoDispatcher {
+func GoMSSQLDispatcher(fs []interface{}) RowsGoDispatcher {
 	dispatcher := &goMSSQLDispatcher{
 		funcMap: map[string]funcInfo{},
 	}

--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -38,6 +38,13 @@ type RowsLogger func(rows *sql.Rows) error
 // __function is the function name, the other arguments are the arguments to the Go function.
 type RowsGoDispatcher func(rows *sql.Rows) error
 
+// DeferredRowsGoDispatcher buffers dispatcher rows until the query has a final outcome.
+// Implementations can decide in Finalize whether buffered calls should run or be skipped.
+type DeferredRowsGoDispatcher interface {
+	ProcessRows(rows *sql.Rows) error
+	Finalize(queryErr error) error
+}
+
 // ResultSets is a tiny wrapper around sql.Rows to help managing whether to call NextResultSet or not.
 // It is fine to instantiate this struct yourself.
 //
@@ -61,11 +68,13 @@ type ResultSets struct {
 	// It will be compared with the lowercase name of the column.
 	LogKeyLowercase string
 
-	// "select _function=MyFunction" will attempt to fall a Go function (in this case MyFunction)
-	// with the remaining arguments to the select as arguments to the function call
-	Dispatcher RowsGoDispatcher
+	// "select _function=MyFunction" will attempt to call a Go function (in this case MyFunction)
+	// with the remaining arguments to the select as arguments to the function call.
+	// Dispatcher can be either a RowsGoDispatcher or a DeferredRowsGoDispatcher.
+	Dispatcher any
 
-	started bool
+	started             bool
+	dispatcherFinalized bool
 }
 
 // hook for tests
@@ -80,7 +89,7 @@ func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *Resu
 		started:    false,
 		Err:        err, // important to return the error unadorned here, as some code e.g. casts it directly to mssql.Error
 		Logger:     Logger(ctx),
-		Dispatcher: Dispatcher(ctx),
+		Dispatcher: dispatcherValue(ctx),
 	}
 }
 
@@ -128,11 +137,41 @@ func (rs *ResultSets) processDispatcherSelect() error {
 		return fmt.Errorf("missing dispatcher")
 	}
 
-	if err := rs.Dispatcher(rs.Rows); err != nil {
-		return err
+	switch dispatcher := rs.Dispatcher.(type) {
+	case RowsGoDispatcher:
+		if err := dispatcher(rs.Rows); err != nil {
+			return err
+		}
+	case DeferredRowsGoDispatcher:
+		if err := dispatcher.ProcessRows(rs.Rows); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported dispatcher type %T", rs.Dispatcher)
 	}
 	// a well-written dispatchers would return rs.Rows.Err(), but just be certain this isn't overlooked...
 	return rs.Rows.Err()
+}
+
+func (rs *ResultSets) finalizeDispatcher(queryErr error) error {
+	if rs.dispatcherFinalized {
+		return queryErr
+	}
+	rs.dispatcherFinalized = true
+
+	dispatcher, ok := rs.Dispatcher.(DeferredRowsGoDispatcher)
+	if !ok {
+		return queryErr
+	}
+
+	if err := dispatcher.Finalize(queryErr); err != nil {
+		if queryErr != nil {
+			return errors.Join(queryErr, err)
+		}
+		return err
+	}
+
+	return queryErr
 }
 
 // NextResult reads the next result set from `rs`, into the type/scanner provided in the `typ`
@@ -170,7 +209,7 @@ func (rs *ResultSets) processAllSpecialSelects() (hadColumns bool, err error) {
 		var cols []string
 		cols, err = rs.Rows.Columns()
 		if err != nil {
-			return false, err
+			return false, rs.finalizeDispatcher(err)
 		}
 		if len(cols) == 0 {
 			// This happens in the event that there's no result sets in the query at all
@@ -179,24 +218,24 @@ func (rs *ResultSets) processAllSpecialSelects() (hadColumns bool, err error) {
 
 		if rs.hasLogColumn(cols) {
 			if err = rs.processLogSelect(); err != nil {
-				return false, err
+				return false, rs.finalizeDispatcher(err)
 			}
 			if err = rs.nextResultSet(); err != nil {
-				return false, err
+				return false, rs.finalizeDispatcher(err)
 			}
 		} else if rs.hasDispatcherColumn(cols) {
 			if err = rs.processDispatcherSelect(); err != nil {
-				return false, err
+				return false, rs.finalizeDispatcher(err)
 			}
 			if err = rs.nextResultSet(); err != nil {
-				return false, err
+				return false, rs.finalizeDispatcher(err)
 			}
 		} else {
 			// non-logging select; return
 			return true, nil
 		}
 	}
-	return true, nil
+	return true, rs.finalizeDispatcher(nil)
 }
 
 func (rs *ResultSets) Done() bool {
@@ -207,8 +246,13 @@ func (rs *ResultSets) nextResultSet() error {
 	if rs.Rows.NextResultSet() {
 		return nil
 	} else {
+		err := rs.Rows.Err()
 		// we have exhausted the results; automatically close Rows; this also ensures Done() returns true
-		return rs.Close()
+		closeErr := rs.Close()
+		if err != nil {
+			return err
+		}
+		return closeErr
 	}
 }
 
@@ -255,7 +299,7 @@ func Next(rs *ResultSets, scanner Target) error {
 		if scanner != nil {
 			if err := scanner.ScanRow(rs.Rows); err != nil {
 				defer func() { _ = rs.Close() }()
-				return err
+				return rs.finalizeDispatcher(err)
 			}
 		}
 	}
@@ -264,17 +308,17 @@ func Next(rs *ResultSets, scanner Target) error {
 		defer func() { _ = rs.Close() }()
 		// If we return the error here, we'll miss processing the result sets up to this point
 		// Instead of returning the error, we set rs.Err so that next call to Next will return the error
-		rs.Err = err
+		rs.Err = rs.finalizeDispatcher(err)
 		return nil
 	}
 
 	if err := rs.nextResultSet(); err != nil {
 		defer func() { _ = rs.Close() }()
-		return err
+		return rs.finalizeDispatcher(err)
 	}
 
 	if _, err := rs.processAllSpecialSelects(); err != nil {
-		return err
+		return rs.finalizeDispatcher(err)
 	}
 
 	if rs.DoneAfterNext {
@@ -285,6 +329,18 @@ func Next(rs *ResultSets, scanner Target) error {
 	}
 
 	return nil
+}
+
+func drain(rs *ResultSets) error {
+	for {
+		err := NextNoScanner(rs)
+		if err != nil {
+			if err == ErrNoMoreSets {
+				return nil
+			}
+			return err
+		}
+	}
 }
 
 func MustNext(rs *ResultSets, scanner Target) {
@@ -360,6 +416,9 @@ func Query(
 			return err
 		}
 	}
+	if err := drain(rs); err != nil {
+		return err
+	}
 	success = true
 	if err := rs.Close(); err != nil {
 		return err
@@ -392,6 +451,10 @@ func Query2[T1 any, T2 any](
 
 	t2, err := NextResult(rs, type2)
 	if err != nil {
+		return zero1, zero2, err
+	}
+
+	if err = drain(rs); err != nil {
 		return zero1, zero2, err
 	}
 
@@ -435,6 +498,10 @@ func Query3[T1 any, T2 any, T3 any](
 
 	t3, err := NextResult(rs, type3)
 	if err != nil {
+		return zero1, zero2, zero3, err
+	}
+
+	if err = drain(rs); err != nil {
 		return zero1, zero2, zero3, err
 	}
 
@@ -485,6 +552,10 @@ func Query4[T1 any, T2 any, T3 any, T4 any](
 
 	t4, err := NextResult(rs, type4)
 	if err != nil {
+		return zero1, zero2, zero3, zero4, err
+	}
+
+	if err = drain(rs); err != nil {
 		return zero1, zero2, zero3, zero4, err
 	}
 

--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -34,13 +34,8 @@ func (_ NotImplementedSqlResult) RowsAffected() (int64, error) {
 // The convention is that the first column will always contain the log level.
 type RowsLogger func(rows *sql.Rows) error
 
-// RowsGoDispatcher takes a sql.Rows and calls a Go function.  The first argument,
-// __function is the function name, the other arguments are the arguments to the Go function.
-type RowsGoDispatcher func(rows *sql.Rows) error
-
-// DeferredRowsGoDispatcher buffers dispatcher rows until the query has a final outcome.
-// Implementations can decide in Finalize whether buffered calls should run or be skipped.
-type DeferredRowsGoDispatcher interface {
+// RowsGoDispatcher processes dispatcher result sets and finalizes them when the query outcome is known.
+type RowsGoDispatcher interface {
 	ProcessRows(rows *sql.Rows) error
 	Finalize(queryErr error) error
 }
@@ -69,9 +64,8 @@ type ResultSets struct {
 	LogKeyLowercase string
 
 	// "select _function=MyFunction" will attempt to call a Go function (in this case MyFunction)
-	// with the remaining arguments to the select as arguments to the function call.
-	// Dispatcher can be either a RowsGoDispatcher or a DeferredRowsGoDispatcher.
-	Dispatcher any
+	// with the remaining arguments to the select as arguments to the function call once the query succeeds.
+	Dispatcher RowsGoDispatcher
 
 	started             bool
 	dispatcherFinalized bool
@@ -89,7 +83,7 @@ func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *Resu
 		started:    false,
 		Err:        err, // important to return the error unadorned here, as some code e.g. casts it directly to mssql.Error
 		Logger:     Logger(ctx),
-		Dispatcher: dispatcherValue(ctx),
+		Dispatcher: Dispatcher(ctx),
 	}
 }
 
@@ -137,17 +131,8 @@ func (rs *ResultSets) processDispatcherSelect() error {
 		return fmt.Errorf("missing dispatcher")
 	}
 
-	switch dispatcher := rs.Dispatcher.(type) {
-	case RowsGoDispatcher:
-		if err := dispatcher(rs.Rows); err != nil {
-			return err
-		}
-	case DeferredRowsGoDispatcher:
-		if err := dispatcher.ProcessRows(rs.Rows); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unsupported dispatcher type %T", rs.Dispatcher)
+	if err := rs.Dispatcher.ProcessRows(rs.Rows); err != nil {
+		return err
 	}
 	// a well-written dispatchers would return rs.Rows.Err(), but just be certain this isn't overlooked...
 	return rs.Rows.Err()
@@ -159,12 +144,11 @@ func (rs *ResultSets) finalizeDispatcher(queryErr error) error {
 	}
 	rs.dispatcherFinalized = true
 
-	dispatcher, ok := rs.Dispatcher.(DeferredRowsGoDispatcher)
-	if !ok {
+	if rs.Dispatcher == nil {
 		return queryErr
 	}
 
-	if err := dispatcher.Finalize(queryErr); err != nil {
+	if err := rs.Dispatcher.Finalize(queryErr); err != nil {
 		if queryErr != nil {
 			return errors.Join(queryErr, err)
 		}
@@ -584,7 +568,6 @@ func ExecContext(
 			return nil, err
 		}
 	}
-	return NotImplementedSqlResult{}, nil
 }
 
 func Exec(querier CtxQuerier, qry string, args ...any) (sql.Result, error) {

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -317,6 +317,43 @@ func TestDispatcherRuntimeErrorsAndCornerCases(t *testing.T) {
 	}
 }
 
+func TestDispatcherDefersUntilQuerySuccessfullyCompletes(t *testing.T) {
+	qry := `
+select 1;
+select _function='TestFunction', component = 'abc', val=1, time=1.23;
+select 2;
+`
+
+	ctx := querysql.WithDispatcher(context.Background(), querysql.GoMSSQLDispatcher([]interface{}{
+		testhelper.TestFunction,
+	}))
+	rs := querysql.New(ctx, sqldb, qry)
+	testhelper.ResetTestFunctionsCalled()
+
+	assert.Equal(t, 1, querysql.MustNextResult(rs, querysql.SingleOf[int]))
+	assert.False(t, testhelper.TestFunctionsCalled["TestFunction"])
+
+	assert.Equal(t, 2, querysql.MustNextResult(rs, querysql.SingleOf[int]))
+	assert.True(t, testhelper.TestFunctionsCalled["TestFunction"])
+}
+
+func TestDispatcherSkippedWhenLaterQueryFails(t *testing.T) {
+	qry := `
+select _function='TestFunction', component = 'abc', val=1, time=1.23;
+throw 55002, 'Here is an error', 1;
+`
+
+	ctx := querysql.WithDispatcher(context.Background(), querysql.GoMSSQLDispatcher([]interface{}{
+		testhelper.TestFunction,
+	}))
+	testhelper.ResetTestFunctionsCalled()
+
+	_, err := querysql.ExecContext(ctx, sqldb, qry)
+	require.Error(t, err)
+	assert.Equal(t, "mssql: Here is an error", err.Error())
+	assert.False(t, testhelper.TestFunctionsCalled["TestFunction"])
+}
+
 func TestMultipleRowsetsPointers(t *testing.T) {
 	qry := `
 -- single scalar
@@ -550,6 +587,24 @@ func TestQueryPointers(t *testing.T) {
 	assert.Equal(t, []int{3, 4}, b)
 	assert.Equal(t, []string{"hello"}, c)
 	assert.Equal(t, []int(nil), d)
+}
+
+func TestQueryDrainsDeferredDispatchers(t *testing.T) {
+	var a int
+	ctx := querysql.WithDispatcher(context.Background(), querysql.GoMSSQLDispatcher([]interface{}{
+		testhelper.TestFunction,
+	}))
+	testhelper.ResetTestFunctionsCalled()
+
+	err := querysql.Query(
+		[]querysql.Target{querysql.SingleInto(&a)},
+		ctx, sqldb, `
+		select 1;
+		select _function='TestFunction', component = 'abc', val=1, time=1.23;
+	`)
+	require.NoError(t, err)
+	assert.Equal(t, 1, a)
+	assert.True(t, testhelper.TestFunctionsCalled["TestFunction"])
 }
 
 func TestPropagateSyntaxError1(t *testing.T) {


### PR DESCRIPTION
## Context
- `_function` dispatch currently happens as soon as querysql reads each dispatcher result set.
- A later SQL error can still fail the query after those side effects have already been emitted.
- That makes generic dispatcher side effects unsafe for metrics and any other work that should only happen once the query outcome is known.

## Changes summary
- change the dispatcher contract so dispatchers process `_function` result sets first and finalize only after the query outcome is known
- update `GoMSSQLDispatcher` to queue reflected Go calls and only execute them after successful query completion
- remove the old immediate-dispatch compatibility path, so consumers upgrading to this version must use the finalization-aware dispatcher API
- skip buffered dispatch on later query errors, drain the `Query` helpers to completion, and cover the new timing with tests

## Test plan
- [x] `go test ./querysql/...`
- [x] `go test ./...`