### PR TITLE
fix(querysql): clarify database connection EOFs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
         go-version: '1.26'
 
     - name: Start db
-      run: docker compose -f docker-compose.test.yml up -d
+      run: docker compose -f docker-compose.test.yml up -d --wait --wait-timeout 60
 
     - name: Test
       run: go test -v ./...

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,3 +13,9 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: VippsPw1
+    healthcheck:
+      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "localhost", "-U", "sa", "-P", "VippsPw1", "-b", "-Q", "SELECT 1"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 10s

--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -79,13 +79,13 @@ func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *Resu
 		// The Microsoft SQL driver unfortunately exposes an unexpected connection
 		// closure as a bare EOF instead of wrapping it with database context. Add that
 		// context here despite the brittleness of identifying the failure through a
-		// generic sentinel, and preserve EOF for errors.Is.
+		// generic sentinel. We preserve EOF via wrapping in case callers depend on it.
 		err = fmt.Errorf("database connection closed unexpectedly while executing query: %w", err)
 	}
 	return &ResultSets{
 		Rows:       rows,
 		started:    false,
-		Err:        err, // inspect SQL errors with errors.As or errors.Is, never with direct type assertions
+		Err:        err, // callers should inspect SQL errors with errors.As or errors.Is, never with direct type assertions
 		Logger:     Logger(ctx),
 		Dispatcher: Dispatcher(ctx),
 	}

--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -80,7 +80,7 @@ func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *Resu
 		// closure as a bare EOF instead of wrapping it with database context. Add that
 		// context here despite the brittleness of identifying the failure through a
 		// generic sentinel. We preserve EOF via wrapping in case callers depend on it.
-		err = fmt.Errorf("database connection closed unexpectedly while executing query: %w", err)
+		err = fmt.Errorf("querysql: database connection closed unexpectedly while executing query: %w", err)
 	}
 	return &ResultSets{
 		Rows:       rows,

--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -75,10 +75,17 @@ var _closeHook = func(r io.Closer) error {
 
 func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *ResultSets {
 	rows, err := querier.QueryContext(ctx, qry, args...)
+	if errors.Is(err, io.EOF) {
+		// An EOF returned by QueryContext means the database connection closed before
+		// the query completed. Add that missing context while preserving EOF for
+		// errors.Is. Other SQL errors must remain unadorned because callers may type
+		// assert them directly, for example to mssql.Error.
+		err = fmt.Errorf("database connection closed unexpectedly while executing query: %w", err)
+	}
 	return &ResultSets{
 		Rows:       rows,
 		started:    false,
-		Err:        err, // important to return the error unadorned here, as some code e.g. casts it directly to mssql.Error
+		Err:        err,
 		Logger:     Logger(ctx),
 		Dispatcher: Dispatcher(ctx),
 	}

--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -76,11 +76,10 @@ var _closeHook = func(r io.Closer) error {
 func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *ResultSets {
 	rows, err := querier.QueryContext(ctx, qry, args...)
 	if errors.Is(err, io.EOF) {
-		// An EOF returned by QueryContext means the database connection closed before
-		// the query completed. Add that missing context while preserving EOF for
-		// errors.Is. Other SQL errors remain unadorned for compatibility, but callers
-		// must use errors.As or errors.Is instead of direct type assertions because
-		// errors may be wrapped.
+		// The Microsoft SQL driver unfortunately exposes an unexpected connection
+		// closure as a bare EOF instead of wrapping it with database context. Add that
+		// context here despite the brittleness of identifying the failure through a
+		// generic sentinel, and preserve EOF for errors.Is.
 		err = fmt.Errorf("database connection closed unexpectedly while executing query: %w", err)
 	}
 	return &ResultSets{

--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -80,7 +80,7 @@ func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *Resu
 		// closure as a bare EOF instead of wrapping it with database context. Add that
 		// context here despite the brittleness of identifying the failure through a
 		// generic sentinel. We preserve EOF via wrapping in case callers depend on it.
-		err = fmt.Errorf("querysql: database connection closed unexpectedly while executing query: %w", err)
+		err = fmt.Errorf("querysql: db connection closed unexpectedly while executing query: %w", err)
 	}
 	return &ResultSets{
 		Rows:       rows,

--- a/querysql/querysql.go
+++ b/querysql/querysql.go
@@ -78,14 +78,15 @@ func New(ctx context.Context, querier CtxQuerier, qry string, args ...any) *Resu
 	if errors.Is(err, io.EOF) {
 		// An EOF returned by QueryContext means the database connection closed before
 		// the query completed. Add that missing context while preserving EOF for
-		// errors.Is. Other SQL errors must remain unadorned because callers may type
-		// assert them directly, for example to mssql.Error.
+		// errors.Is. Other SQL errors remain unadorned for compatibility, but callers
+		// must use errors.As or errors.Is instead of direct type assertions because
+		// errors may be wrapped.
 		err = fmt.Errorf("database connection closed unexpectedly while executing query: %w", err)
 	}
 	return &ResultSets{
 		Rows:       rows,
 		started:    false,
-		Err:        err,
+		Err:        err, // inspect SQL errors with errors.As or errors.Is, never with direct type assertions
 		Logger:     Logger(ctx),
 		Dispatcher: Dispatcher(ctx),
 	}

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -33,7 +33,7 @@ func (errorQuerier) QueryRowContext(context.Context, string, ...any) *sql.Row {
 func TestNewExplainsDatabaseEOF(t *testing.T) {
 	rs := querysql.New(context.Background(), errorQuerier{err: io.EOF}, "select 1")
 
-	require.EqualError(t, rs.Err, "querysql: database connection closed unexpectedly while executing query: EOF")
+	require.EqualError(t, rs.Err, "querysql: db connection closed unexpectedly while executing query: EOF")
 	require.ErrorIs(t, rs.Err, io.EOF)
 }
 

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -37,12 +37,13 @@ func TestNewExplainsDatabaseEOF(t *testing.T) {
 	require.ErrorIs(t, rs.Err, io.EOF)
 }
 
-func TestNewLeavesOtherDatabaseErrorsUnadorned(t *testing.T) {
+func TestNewLeavesOtherDatabaseErrorsDiscoverable(t *testing.T) {
 	sqlErr := mssql.Error{Number: 40197, Message: "service error"}
 	rs := querysql.New(context.Background(), errorQuerier{err: sqlErr}, "select 1")
 
-	_, ok := rs.Err.(mssql.Error)
-	require.True(t, ok)
+	var actual mssql.Error
+	require.ErrorAs(t, rs.Err, &actual)
+	require.Equal(t, sqlErr.Number, actual.Number)
 }
 
 // Scan implements the sql.Scanner interface.

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -33,7 +33,7 @@ func (errorQuerier) QueryRowContext(context.Context, string, ...any) *sql.Row {
 func TestNewExplainsDatabaseEOF(t *testing.T) {
 	rs := querysql.New(context.Background(), errorQuerier{err: io.EOF}, "select 1")
 
-	require.EqualError(t, rs.Err, "database connection closed unexpectedly while executing query: EOF")
+	require.EqualError(t, rs.Err, "querysql: database connection closed unexpectedly while executing query: EOF")
 	require.ErrorIs(t, rs.Err, io.EOF)
 }
 

--- a/querysql/querysql_test.go
+++ b/querysql/querysql_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
+	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +17,33 @@ import (
 )
 
 type MyArray [5]byte
+
+type errorQuerier struct {
+	err error
+}
+
+func (q errorQuerier) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, q.err
+}
+
+func (errorQuerier) QueryRowContext(context.Context, string, ...any) *sql.Row {
+	return nil
+}
+
+func TestNewExplainsDatabaseEOF(t *testing.T) {
+	rs := querysql.New(context.Background(), errorQuerier{err: io.EOF}, "select 1")
+
+	require.EqualError(t, rs.Err, "database connection closed unexpectedly while executing query: EOF")
+	require.ErrorIs(t, rs.Err, io.EOF)
+}
+
+func TestNewLeavesOtherDatabaseErrorsUnadorned(t *testing.T) {
+	sqlErr := mssql.Error{Number: 40197, Message: "service error"}
+	rs := querysql.New(context.Background(), errorQuerier{err: sqlErr}, "select 1")
+
+	_, ok := rs.Err.(mssql.Error)
+	require.True(t, ok)
+}
 
 // Scan implements the sql.Scanner interface.
 func (u *MyArray) Scan(src interface{}) error {


### PR DESCRIPTION
## Context

Microsoft's SQL driver can surface a failed database query as only `EOF`, because its retryable connection error delegates its message to the underlying `io.EOF`. During a production investigation, 2,350 of the 2,383 EOF errors reaching the dataflow run boundary over 30 days came from one SQL query path, but the error text did not identify the database connection as the source.

`querysql` has historically left SQL errors unadorned. Callers should nevertheless inspect errors with `errors.As` or `errors.Is`, never direct type assertions, because selected errors may gain useful context while preserving their error chain.

## Changes

- identify EOF errors returned by `QueryContext` as unexpected database connection closure
- preserve EOF in the error chain for `errors.Is`
- leave other SQL errors unchanged while documenting `errors.As` and `errors.Is` as the supported inspection contract